### PR TITLE
Add QQA4CO under Open Source Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Learnergy: Energy-based Machine Learners.](https://github.com/gugarosa/learnergy
 
 - [ ] [Maes, F. (2009). \
  Nieme: Large-scale energy-based models. The Journal of Machine Learning Research, 10, 743-746.](https://www.jmlr.org/papers/volume10/maes09a/maes09a.pdf)*[[code (however is missing in the webpage)]](http://nieme.lip6.fr/)*
+- [ ] [2025. QQA4CO: PyTorch toolkit for combinatorial optimisation via Parallel Quasi-Quantum Annealing (PQQA, ICLR 2025), bundling SA / PI-GNN / CRA-PI-GNN baselines under one energy-landscape annealing API.](https://github.com/Yuma-Ichikawa/QQA4CO)
 
 
 ## Tutorials & Talks & Blogs


### PR DESCRIPTION
Adding **QQA4CO** under `## Open Source Libraries`.

Why this fits an EBM list: PQQA can be read as a structured energy-based model — the quasi-quantum schedule smoothly transitions between a convex energy minimised at half-integral values and the original discrete objective, while parallel-replica communication on GPU accelerates exploration. The toolkit ships 17 problem classes including QUBO, Ising, Edwards–Anderson, Sherrington–Kirkpatrick, Hopfield associative memory and binary perceptron — i.e. the canonical energy-landscape models EBM researchers benchmark on.

- Paper: https://openreview.net/forum?id=9EfBeXaXf0 (ICLR 2025)
- arXiv: https://arxiv.org/abs/2409.02135
- PyPI: `pip install qqa` · License: BSD-3-Clause-Clear · DOI: [10.5281/zenodo.19648231](https://doi.org/10.5281/zenodo.19648231)

Format follows the existing `- [ ] [YYYY. description](URL)` convention used in the section.